### PR TITLE
all: automatically propagate exported env.vars. to client packages

### DIFF
--- a/orch/__init__.py
+++ b/orch/__init__.py
@@ -12,6 +12,7 @@ from . import envmunge
 
 ## waf imports
 import waflib.Logs as msg
+import waflib.Utils
 
 # NOT from the waf book.  The waf book example for depends_on doesn't work
 from waflib import TaskGen

--- a/orch/envmunge.py
+++ b/orch/envmunge.py
@@ -141,15 +141,36 @@ def collapse_envmungers(mungers):
 def make_envmungers(pkg, all_packages):
     '''Make a environment munger that will apply the export_VARIABLE
     settings from all dependency packages indicated by the
-    "environment" package variable and any specified by
-    buildenv_VARIABLE in the package itself.
+    "environment" package variable (and the export_VAR from 'depends' packages)
+    and any specified by buildenv_VARIABLE in the package itself.
     '''
     mungers = list()
-    for other_pkg in resolve_packages(all_packages, pkg.get('environment')):
+    autoenv = []
+    deps = pkg.get('depends') or []
+    if isinstance(deps, type("")): deps = deps.split()
+    
+    for dep in deps:
+        _, step = dep.split(':')
+        what = step.split('_')[0]
+        if what in all_packages:
+            autoenv.append('package:%s' % what)
+        else: # FIXME: assume this is a group, then.
+            autoenv.append('group:%s' % what)
+
+    if pkg.get('environment'):
+        autoenv.extend(pkg.get('environment'))
+        
+    for other_pkg in resolve_packages(all_packages, autoenv):
         new = make_envmungers_from_package(other_pkg)
         mungers.append(new)
+        pass
+
     new = make_envmungers_from_package(pkg, prefix='buildenv_')
     mungers.append(new)
+
+    new = make_envmungers_from_package(pkg, prefix='export_')
+    mungers.append(new)
+
     return collapse_envmungers(mungers)
 
 def apply_envmungers(environ, mungers):

--- a/orch/features.py
+++ b/orch/features.py
@@ -22,7 +22,7 @@ def _worch_exec_command(task, cmd, **kw):
      - printout the content of that file when the command fails
     '''
     msg.debug('orch: %s...' % task.name)
-    cwd = getattr(task, 'cwd', task.generator.bld.path.abspath())
+    cwd = getattr(task, 'cwd', task.generator.bld.out_dir)
     flog = open(osp.join(cwd, "worch_%s.log.txt" % task.name), 'w')
     cmd_dict = dict(kw)
     cmd_dict.update({
@@ -382,6 +382,7 @@ def feature_git(self):
              source = f_urlfile,
              target = f_unpack,
              depends_on = pfi.get_deps('checkout'),
+             cwd = d_source.abspath(),
              env = pfi.env)
 
     return
@@ -447,6 +448,7 @@ def feature_hg(self):
              source = f_urlfile,
              target = f_unpack,
              depends_on = pfi.get_deps('checkout'),
+             cwd = d_source.abspath(),
              env = pfi.env)
 
     return
@@ -511,6 +513,7 @@ def feature_svn(self):
              source = f_urlfile,
              target = f_unpack,
              depends_on = pfi.get_deps('checkout'),
+             cwd = d_source.abspath(),
              env = pfi.env)
 
     return


### PR DESCRIPTION
automatically propagate exported env.vars to client packages.
Note: this is NOT a recursive propagation. (should it be ?)
