### PR TITLE
deconf: limit environment passed to deconf

### DIFF
--- a/orch/deconf.py
+++ b/orch/deconf.py
@@ -140,7 +140,6 @@ def resolve(cfg, sec, **kwds):
 
     secitems = dict(cfg.items(sec))
 
-    secitems.update(kwds)
     # get special keytype section governing the hierarchy schema
     keytype = dict(cfg.items('keytype'))
 
@@ -153,7 +152,7 @@ def resolve(cfg, sec, **kwds):
         lst = []
         for name in to_list(v):
             other_sec = get_first_typed_section(cfg, typ, name)
-            other = resolve(cfg, other_sec)
+            other = resolve(cfg, other_sec, **kwds)
             other.setdefault(typ,name)
             lst.append(other)
         ret[k] = lst


### PR DESCRIPTION
this one is a bit more controversial.
in hwaf I do store a fair bit of non-os.environ stuff in the ctx.env (dicts of projects trees, stack of operations modules applied on the environment, etc...)

passing the full environment as in that callstack:

https://github.com/hwaf/worch/blob/master/orch/waffuncs.py#L57
https://github.com/hwaf/worch/blob/master/orch/pkgconf.py#L99

breaks hwaf.
