### PR TITLE
pypackage: introduce dummy 'prepare' step for better integration 

### DIFF
--- a/orch/features/feature_pypackage.py
+++ b/orch/features/feature_pypackage.py
@@ -39,7 +39,7 @@ def feature_pypackage(tgen):
 
     tgen.step('build',
               rule = tgen.worch.format('{build_cmd} {build_cmd_options}'),
-              source = tgen.control_node('unpack'),
+              source = tgen.control_node('prepare'),
               target = tgen.worch.build_target_path,
               cwd = tgen.worch.source_unpacked_path)
 


### PR DESCRIPTION
introduce a dummy 'prepare' step.
other places in the codebase assume 'prepare' is the package entry point (to insert dependencies or e.g. feature_patch)
