### PR TITLE
envmunge: honor ctx.env.env and pass it down to mungers.apply

### DIFF
--- a/orch/envmunge.py
+++ b/orch/envmunge.py
@@ -122,7 +122,8 @@ def decompose(cfg, suite):
     for pkg_name, pkg in pd.items():
 
         mlist = make_envmungers(pkg, pd)
-        menv = mungers.apply(mlist)
+        environ = cfg.env.env or dict()
+        menv = mungers.apply(mlist, **environ)
 
         new_env = base_env.derive()
         new_env.munged_env = menv


### PR DESCRIPTION
if a `wscript` or a task carefully crafts a `ctx.env.env` environment, this is dropped on the floor and the worch tasks (and `wafutil.exec_command`) won't pick it up.

this patch tries to properly honor `ctx.env.env` and falls back on `os.environ` otherwise.
